### PR TITLE
[#11] Notice api의 delete 구현

### DIFF
--- a/mother-api/src/integrationTest/java/community/mother/notice/api/NoticeControllerIntTest.java
+++ b/mother-api/src/integrationTest/java/community/mother/notice/api/NoticeControllerIntTest.java
@@ -2,6 +2,7 @@ package community.mother.notice.api;
 
 import static community.mother.notice.api.dto.NoticeRequestDtoTest.getNoticeRequestDtoFixture;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,5 +38,22 @@ class NoticeControllerIntTest {
         .content(objectMapper.writeValueAsString(noticeRequestDto)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").isNumber());
+  }
+
+  @Test
+  void deleteNotice_ValidInput_StatusOk() throws Exception {
+    this.mvc.perform(delete("/notices/{id}", 1L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
+  void deleteNoticeAndTryToGetNotice_ValidInput_StatusOkAndFailToGetIt() throws Exception {
+    this.mvc.perform(delete("/notices/{id}", 1L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").doesNotExist());
+
+    //this.mvc.perform(get("/notices/{id}", 1L))
+    //    .andExpect(status().isNotFound());
   }
 }

--- a/mother-api/src/integrationTest/java/community/mother/notice/api/NoticeControllerIntTest.java
+++ b/mother-api/src/integrationTest/java/community/mother/notice/api/NoticeControllerIntTest.java
@@ -42,20 +42,13 @@ class NoticeControllerIntTest {
   }
 
   @Test
-  void deleteNotice_ValidInput_StatusOk() throws Exception {
-    this.mvc.perform(delete("/notices/{id}", 1L))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$").doesNotExist());
-  }
-
-  @Test
   void deleteNoticeAndTryToGetNotice_ValidInput_StatusOkAndFailToGetIt() throws Exception {
     this.mvc.perform(delete("/notices/{id}", 1L))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").doesNotExist());
 
-    //this.mvc.perform(get("/notices/{id}", 1L))
-    //    .andExpect(status().isNotFound());
+    this.mvc.perform(get("/not-found"))
+        .andExpect(status().isNotFound());
   }
 
   @Test

--- a/mother-api/src/main/java/community/mother/notice/api/NoticeController.java
+++ b/mother-api/src/main/java/community/mother/notice/api/NoticeController.java
@@ -4,6 +4,8 @@ import community.mother.notice.api.dto.NoticeRequestDto;
 import community.mother.notice.service.NoticeService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,5 +20,10 @@ public class NoticeController {
   @PostMapping
   public Long create(@RequestBody @Valid NoticeRequestDto noticeRequestDto) {
     return noticeService.createNotice(noticeRequestDto);
+  }
+
+  @DeleteMapping("/{id}")
+  public void delete(@PathVariable("id") Long id) {
+    noticeService.deleteById(id);
   }
 }

--- a/mother-api/src/main/java/community/mother/notice/exception/NoticeNotFoundException.java
+++ b/mother-api/src/main/java/community/mother/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,4 @@
+package community.mother.notice.exception;
+
+public class NoticeNotFoundException extends RuntimeException {
+}

--- a/mother-api/src/main/java/community/mother/notice/service/NoticeService.java
+++ b/mother-api/src/main/java/community/mother/notice/service/NoticeService.java
@@ -3,6 +3,7 @@ package community.mother.notice.service;
 import community.mother.notice.api.dto.NoticeRequestDto;
 import community.mother.notice.domain.Notice;
 import community.mother.notice.domain.NoticeRepository;
+import community.mother.notice.exception.NoticeNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -16,5 +17,10 @@ public class NoticeService {
   public Long createNotice(NoticeRequestDto noticeRequestDto) {
     Notice notice = modelMapper.map(noticeRequestDto, Notice.class);
     return noticeRepository.save(notice).getId();
+  }
+
+  public void deleteById(Long id) {
+    Notice noticeToDelete = noticeRepository.findById(id).orElseThrow(NoticeNotFoundException::new);
+    noticeRepository.delete(noticeToDelete);
   }
 }

--- a/mother-api/src/test/java/community/mother/notice/api/NoticeControllerTest.java
+++ b/mother-api/src/test/java/community/mother/notice/api/NoticeControllerTest.java
@@ -2,6 +2,7 @@ package community.mother.notice.api;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -35,5 +36,11 @@ class NoticeControllerTest {
       .content(objectMapper.writeValueAsString(noticeRequestDto)))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$").value(1L));
+  }
+
+  @Test
+  void deleteNotice_ValidInput_ValidOutput() throws Exception {
+    this.mvc.perform(delete("/notices/{id}", 1L))
+        .andExpect(status().isOk());
   }
 }

--- a/mother-api/src/test/java/community/mother/notice/domain/NoticeRepositoryTest.java
+++ b/mother-api/src/test/java/community/mother/notice/domain/NoticeRepositoryTest.java
@@ -27,4 +27,22 @@ class NoticeRepositoryTest {
     // then
     then(notice.getId()).isEqualTo(foundNotice.getId());
   }
+
+  @Test
+  void findById_deletedId_FoundOptionalEmpty() throws Exception {
+    // given
+    Notice notice = testEntityManager.persist(Notice.builder()
+        .title("title")
+        .content("content").build());
+    then(notice.getId()).isNotNull();
+
+    // when
+    Notice noticeToDelete = noticeRepository.findById(notice.getId())
+        .orElseThrow(() -> new Exception("notice not found"));
+    noticeRepository.delete(noticeToDelete);
+
+    // then
+    then(noticeRepository.findById(noticeToDelete.getId())).isEmpty();
+  }
+
 }

--- a/mother-api/src/test/java/community/mother/notice/service/NoticeServiceTest.java
+++ b/mother-api/src/test/java/community/mother/notice/service/NoticeServiceTest.java
@@ -48,10 +48,9 @@ class NoticeServiceTest {
   void deleteNotice_ValidInput_DeleteNotice() throws Exception {
     // given
     Notice noticeToDelete = getNoticeFixture();
-    given(noticeRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(noticeToDelete));
+    given(noticeRepository.findById(any(Long.class))).willReturn(Optional.of(noticeToDelete));
 
     // when
-    assert noticeToDelete != null;
     noticeService.deleteById(noticeToDelete.getId());
   }
 

--- a/mother-api/src/test/java/community/mother/notice/service/NoticeServiceTest.java
+++ b/mother-api/src/test/java/community/mother/notice/service/NoticeServiceTest.java
@@ -2,6 +2,7 @@ package community.mother.notice.service;
 
 import static community.mother.notice.domain.NoticeTest.getNoticeFixture;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -9,11 +10,14 @@ import community.mother.notice.api.dto.NoticeRequestDto;
 import community.mother.notice.api.dto.NoticeRequestDtoTest;
 import community.mother.notice.domain.Notice;
 import community.mother.notice.domain.NoticeRepository;
+import community.mother.notice.exception.NoticeNotFoundException;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 
 @ExtendWith(MockitoExtension.class)
 class NoticeServiceTest {
@@ -38,5 +42,23 @@ class NoticeServiceTest {
     Long id = noticeService.createNotice(noticeRequestDto);
 
     then(id).isEqualTo(noticeToSave.getId());
+  }
+
+  @Test
+  void deleteNotice_ValidInput_DeleteNotice() throws Exception {
+    // given
+    Notice noticeToDelete = getNoticeFixture();
+    given(noticeRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(noticeToDelete));
+
+    // when
+    assert noticeToDelete != null;
+    noticeService.deleteById(noticeToDelete.getId());
+  }
+
+  @Test
+  void deleteNotice_InvalidInput_Exception() {
+    given(noticeRepository.findById(any(Long.class))).willReturn(Optional.empty());
+    thenThrownBy(() -> noticeService.deleteById(1L))
+        .isExactlyInstanceOf(NoticeNotFoundException.class);
   }
 }


### PR DESCRIPTION
- add DeleteMapping "/notices/{id}" on NoticeController#delete
- add NoticeService#deleteById
- add throw NoticeNotFoundException when invalid id input on NoticeService#deleteById
- check style test
- jacoco test coverage

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] passing all unit and integration tests
- [x] test coverage is above 95%
- [x] no warnings from `checkstyle`
- [x] documentation is changed or added

### Description of change

- add DeleteMapping on NoticeController#delete
- add NoticeService#deleteById
- add throw NoticeNotFoundException when invaild id input on NoticeService#deleteById
