### PR TITLE
[#24] NoticeService에서 modelMapper 대신 builder 사용

### DIFF
--- a/content-api/build.gradle
+++ b/content-api/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.modelmapper:modelmapper:2.3.5'
     runtimeOnly 'com.h2database:h2'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/mother-api/build.gradle
+++ b/mother-api/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.modelmapper:modelmapper:2.3.5'
     runtimeOnly 'com.h2database:h2'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/mother-api/src/main/java/community/mother/notice/api/NoticeController.java
+++ b/mother-api/src/main/java/community/mother/notice/api/NoticeController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/notices")

--- a/mother-api/src/main/java/community/mother/notice/service/NoticeService.java
+++ b/mother-api/src/main/java/community/mother/notice/service/NoticeService.java
@@ -6,7 +6,6 @@ import community.mother.notice.domain.Notice;
 import community.mother.notice.domain.NoticeRepository;
 import community.mother.notice.exception.NoticeNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,11 +14,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class NoticeService {
   private final NoticeRepository noticeRepository;
-  private final ModelMapper modelMapper = new ModelMapper();
 
   public Long createNotice(NoticeRequestDto noticeRequestDto) {
-    Notice notice = modelMapper.map(noticeRequestDto, Notice.class);
-    return noticeRepository.save(notice).getId();
+    return noticeRepository.save(Notice.builder()
+        .title(noticeRequestDto.getTitle())
+        .content(noticeRequestDto.getContent()).build())
+        .getId();
   }
 
   public Page<NoticeResponseDto> readNoticePage(Pageable pageable) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] passing all unit and integration tests
- [x] test coverage is above 95%
- [x] no warnings from `checkstyle`

### Description of change

- ModelMapper 대신 builder 사용
- ModelMapper 의존성 제거
